### PR TITLE
feat: expose service key from logdna resource key

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ No modules.
 | <a name="output_logdna_manager_key_name"></a> [logdna\_manager\_key\_name](#output\_logdna\_manager\_key\_name) | The LogDNA manager key name |
 | <a name="output_logdna_name"></a> [logdna\_name](#output\_logdna\_name) | The name of the provisioned LogDNA instance. |
 | <a name="output_logdna_resource_group_id"></a> [logdna\_resource\_group\_id](#output\_logdna\_resource\_group\_id) | The resource group where LogDNA instance resides |
+| <a name="output_logdna_resource_key"></a> [logdna\_resource\_key](#output\_logdna\_resource\_key) | LogDNA service key for agents to use |
 | <a name="output_region"></a> [region](#output\_region) | Region that instance(s) are provisioned to. |
 | <a name="output_sysdig_access_key"></a> [sysdig\_access\_key](#output\_sysdig\_access\_key) | Sysdig access key for agents to use |
 | <a name="output_sysdig_crn"></a> [sysdig\_crn](#output\_sysdig\_crn) | The id of the provisioned Sysdig instance. |

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -288,7 +288,7 @@
       "description": "The id of the provisioned Activity Tracker instance.",
       "pos": {
         "filename": "outputs.tf",
-        "line": 82
+        "line": 88
       }
     },
     "activity_tracker_guid": {
@@ -296,7 +296,7 @@
       "description": "The guid of the provisioned Activity Tracker instance.",
       "pos": {
         "filename": "outputs.tf",
-        "line": 88
+        "line": 94
       }
     },
     "activity_tracker_manager_key_name": {
@@ -304,7 +304,7 @@
       "description": "The Activity Tracker manager key name",
       "pos": {
         "filename": "outputs.tf",
-        "line": 111
+        "line": 117
       }
     },
     "activity_tracker_name": {
@@ -312,7 +312,7 @@
       "description": "The name of the provisioned Activity Tracker instance.",
       "pos": {
         "filename": "outputs.tf",
-        "line": 93
+        "line": 99
       }
     },
     "activity_tracker_resource_group_id": {
@@ -320,7 +320,7 @@
       "description": "The resource group where Activity Tracker instance resides",
       "pos": {
         "filename": "outputs.tf",
-        "line": 98
+        "line": 104
       }
     },
     "activity_tracker_resource_key": {
@@ -329,7 +329,7 @@
       "sensitive": true,
       "pos": {
         "filename": "outputs.tf",
-        "line": 104
+        "line": 110
       }
     },
     "logdna_crn": {
@@ -354,7 +354,7 @@
       "sensitive": true,
       "pos": {
         "filename": "outputs.tf",
-        "line": 34
+        "line": 40
       }
     },
     "logdna_manager_key_name": {
@@ -362,7 +362,7 @@
       "description": "The LogDNA manager key name",
       "pos": {
         "filename": "outputs.tf",
-        "line": 40
+        "line": 46
       }
     },
     "logdna_name": {
@@ -379,6 +379,15 @@
       "pos": {
         "filename": "outputs.tf",
         "line": 29
+      }
+    },
+    "logdna_resource_key": {
+      "name": "logdna_resource_key",
+      "description": "LogDNA service key for agents to use",
+      "sensitive": true,
+      "pos": {
+        "filename": "outputs.tf",
+        "line": 34
       }
     },
     "region": {
@@ -398,7 +407,7 @@
       "sensitive": true,
       "pos": {
         "filename": "outputs.tf",
-        "line": 68
+        "line": 74
       }
     },
     "sysdig_crn": {
@@ -406,7 +415,7 @@
       "description": "The id of the provisioned Sysdig instance.",
       "pos": {
         "filename": "outputs.tf",
-        "line": 48
+        "line": 54
       }
     },
     "sysdig_guid": {
@@ -414,7 +423,7 @@
       "description": "The guid of the provisioned Sisdig instance.",
       "pos": {
         "filename": "outputs.tf",
-        "line": 53
+        "line": 59
       }
     },
     "sysdig_manager_key_name": {
@@ -422,7 +431,7 @@
       "description": "The Sysdig manager key name",
       "pos": {
         "filename": "outputs.tf",
-        "line": 74
+        "line": 80
       }
     },
     "sysdig_name": {
@@ -430,7 +439,7 @@
       "description": "The name of the provisioned Sysdig instance.",
       "pos": {
         "filename": "outputs.tf",
-        "line": 58
+        "line": 64
       }
     },
     "sysdig_resource_group_id": {
@@ -438,7 +447,7 @@
       "description": "The resource group where Sysdig monitor instance resides",
       "pos": {
         "filename": "outputs.tf",
-        "line": 63
+        "line": 69
       }
     }
   },

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,6 +31,12 @@ output "logdna_resource_group_id" {
   description = "The resource group where LogDNA instance resides"
 }
 
+output "logdna_resource_key" {
+  value       = length(ibm_resource_key.log_dna_resource_key) > 0 ? ibm_resource_key.log_dna_resource_key[0].credentials["service_key"] : null
+  description = "LogDNA service key for agents to use"
+  sensitive   = true
+}
+
 output "logdna_ingestion_key" {
   value       = length(ibm_resource_key.log_dna_resource_key) > 0 ? ibm_resource_key.log_dna_resource_key[0].credentials.ingestion_key : null
   description = "LogDNA ingest key for agents to use"


### PR DESCRIPTION
### Description

Expose the service key from the resource key of the logdna instance. The equivalent key information that is already exposed for the activity tracker instance.

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [x] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
