### PR TITLE
fix: add wait/depends on for cos auth policy

### DIFF
--- a/modules/cloud_logs/README.md
+++ b/modules/cloud_logs/README.md
@@ -91,6 +91,7 @@ No modules.
 | [ibm_resource_instance.cloud_logs](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/resources/resource_instance) | resource |
 | [ibm_resource_tag.cloud_logs_tag](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/resources/resource_tag) | resource |
 | [random_string.random_tenant_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [time_sleep.wait_for_cos_authorization_policy](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.wait_for_en_authorization_policy](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [ibm_iam_account_settings.iam_account_settings](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/iam_account_settings) | data source |
 

--- a/modules/cloud_logs/main.tf
+++ b/modules/cloud_logs/main.tf
@@ -75,7 +75,7 @@ resource "ibm_iam_authorization_policy" "cos_policy" {
 }
 
 resource "time_sleep" "wait_for_cos_authorization_policy" {
-  depends_on      = [ibm_iam_authorization_policy.cos_policy]
+  depends_on = [ibm_iam_authorization_policy.cos_policy]
   # trigger once if any of the buckets create an auth policy
   count           = anytrue([for _, bucket in var.data_storage : bucket.enabled && !bucket.skip_cos_auth_policy]) ? 1 : 0
   create_duration = "30s"

--- a/modules/cloud_logs/main.tf
+++ b/modules/cloud_logs/main.tf
@@ -5,6 +5,7 @@ locals {
 
 # Cloud Logs
 resource "ibm_resource_instance" "cloud_logs" {
+  depends_on        = [time_sleep.wait_for_cos_authorization_policy]
   name              = local.instance_name
   resource_group_id = var.resource_group_id
   service           = "logs"
@@ -71,6 +72,13 @@ resource "ibm_iam_authorization_policy" "cos_policy" {
     operator = "stringEquals"
     value    = regex("bucket:(.*)", each.value.bucket_crn)[0]
   }
+}
+
+resource "time_sleep" "wait_for_cos_authorization_policy" {
+  depends_on      = [ibm_iam_authorization_policy.cos_policy]
+  # trigger once if any of the buckets create an auth policy
+  count           = anytrue([for _, bucket in var.data_storage : bucket.enabled && !bucket.skip_cos_auth_policy]) ? 1 : 0
+  create_duration = "30s"
 }
 
 ##############################################################################


### PR DESCRIPTION
### Description

add explicit depends on for the auth policy between the cloud logs instance and the COS bucket

resolves https://github.com/terraform-ibm-modules/terraform-ibm-observability-instances/issues/587

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
