### PR TITLE
chore: do not set `backup_metadata_region` in example to prevent test clash

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-12-14T09:23:32Z",
+  "generated_at": "2024-12-15T09:23:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -408,7 +408,6 @@ module "observability_instances" {
     default_targets           = local.target_ids
     permitted_target_regions  = ["us-south", "eu-de", "us-east", "eu-es", "eu-gb", "au-syd", "br-sao", "ca-tor", "eu-es", "jp-tok", "jp-osa", "in-che", "eu-fr2"]
     metadata_region_primary   = "us-south"
-    metadata_region_backup    = "eu-de"
     private_api_endpoint_only = false
   }
 
@@ -446,8 +445,7 @@ module "observability_instances" {
       id = module.observability_instances.metrics_router_targets[local.mr_target_name].id
     }]
     permitted_target_regions  = ["us-south", "eu-de", "us-east", "eu-es", "eu-gb", "au-syd", "br-sao", "ca-tor", "jp-tok", "jp-osa"]
-    primary_metadata_region   = "us-south"
-    backup_metadata_region    = "us-east"
+    primary_metadata_region   = var.region
     private_api_endpoint_only = false
   }
 


### PR DESCRIPTION
### Description

Do not set `backup_metadata_region` in example to prevent test clash

`Error: UpdateSettingsWithContext failed The backup region cannot be the same as the primary region. Valid regions for MetadataRegionBackup are: [eu-gb au-syd us-east us-south eu-es eu-fr2 br-sao ca-tor jp-osa jp-tok].  Your primary region is currently set to eu-de.`

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
