### PR TITLE
fix: removed metrics router setting block in advance example

### DIFF
--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -441,7 +441,7 @@ module "observability_instances" {
   ]
 
   /*
-  Removing the metrics routing settings block to resolve test clashes in the pipeline - https://github.ibm.com/GoldenEye/issues/issues/12223
+  Uncomment below to set metrics router settings. A `primary_metadata_region` is required to be set before metrics routing can be configured.
   metrics_router_settings = {
     default_targets = [{
       id = module.observability_instances.metrics_router_targets[local.mr_target_name].id

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -440,7 +440,7 @@ module "observability_instances" {
     }
   ]
 
-  /* 
+  /*
   Removing the metrics routing settings block to resolve test clashes in the pipeline - https://github.ibm.com/GoldenEye/issues/issues/12223
   metrics_router_settings = {
     default_targets = [{

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -440,6 +440,8 @@ module "observability_instances" {
     }
   ]
 
+  /* 
+  Removing the metrics routing settings block to resolve test clashes in the pipeline - https://github.ibm.com/GoldenEye/issues/issues/12223
   metrics_router_settings = {
     default_targets = [{
       id = module.observability_instances.metrics_router_targets[local.mr_target_name].id
@@ -448,6 +450,7 @@ module "observability_instances" {
     primary_metadata_region   = var.region
     private_api_endpoint_only = false
   }
+  */
 
   # CBR
   cbr_rule_at_region = var.region

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -57,8 +57,7 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 	return options
 }
 func TestRunAdvanceExampleInSchematics(t *testing.T) {
-	// https://github.ibm.com/GoldenEye/issues/issues/12223
-	// Avoid t.Parallel() to avoid test clashes
+	t.Parallel()
 
 	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
 		Testing: t,
@@ -91,8 +90,7 @@ func TestRunAdvanceExampleInSchematics(t *testing.T) {
 }
 
 func TestRunUpgradeExample(t *testing.T) {
-	// https://github.ibm.com/GoldenEye/issues/issues/12223
-	// Avoid t.Parallel() to avoid test clashes
+	t.Parallel()
 
 	options := setupOptions(t, "obs-upg", advanceExampleTerraformDir)
 	output, err := options.RunTestUpgrade()


### PR DESCRIPTION
### Description

Removing the metrics router setting part from the advanced example as it is causing intermittent pipeline failure.


<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
