### PR TITLE
Add deprecation and migration docs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-05-11T13:20:07Z",
+  "generated_at": "2025-05-11T13:28:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,8 +82,26 @@
         "hashed_secret": "49901d945ad6da0f0af47691f305daf994d9d2c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 68,
+        "line_number": 70,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/migration.md": [
+      {
+        "hashed_secret": "3b5bf5f75003778663c521c8c35ad277227dd4f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 102,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b189b83761e07d4abce58374ebea3c570387744b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 107,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-12-15T09:23:32Z",
+  "generated_at": "2025-05-11T13:20:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "49901d945ad6da0f0af47691f305daf994d9d2c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 68,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 For more information on migrating to the new modules see [Migrating to replacement modules](docs/migration.md).
 
+---
+
 [![Graduated (Supported)](https://img.shields.io/badge/Status-Graduated%20(Supported)-brightgreen)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Terraform IBM Observability instances module
 
+---
+🕸️ Archived: This repo is no longer maintained and is archived. Please update your terraform code to use the following modules which are direct replacements for this module:
+
+- [terraform-ibm-cloud-logs](https://github.com/terraform-ibm-modules/terraform-ibm-cloud-logs)
+- [terraform-ibm-cloud-monitoring](https://github.com/terraform-ibm-modules/terraform-ibm-cloud-monitoring)
+- [terraform-ibm-activity-tracker](https://github.com/terraform-ibm-modules/terraform-ibm-activity-tracker)
+
+For more information on migrating to the new modules see [Migrating to replacement modules](docs/migration.md).
+
 [![Graduated (Supported)](https://img.shields.io/badge/Status-Graduated%20(Supported)-brightgreen)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,126 @@
+# Migrating to replacement modules
+
+The [terraform-ibm-observability-instances](https://github.com/terraform-ibm-modules/terraform-ibm-observability-instances) module is no longer maintained and has been replaced by the following 3 modules:
+
+- [terraform-ibm-cloud-logs](https://github.com/terraform-ibm-modules/terraform-ibm-cloud-logs)
+- [terraform-ibm-cloud-monitoring](https://github.com/terraform-ibm-modules/terraform-ibm-cloud-monitoring)
+- [terraform-ibm-activity-tracker](https://github.com/terraform-ibm-modules/terraform-ibm-activity-tracker)
+
+In order to migrate to the new modules, you need to update your terraform code to now call each of the new modules individually. For example, your current code will look something like this:
+
+```hcl
+module "observability_instances" {
+  source  = "terraform-ibm-modules/observability-instances/ibm"
+  version = "3.5.2"
+  ...
+  ...
+}
+```
+
+And your new code will look like this:
+```hcl
+module "cloud_logs" {
+  source  = "terraform-ibm-modules/cloud-logs/ibm"
+  version = "1.3.1"
+  ...
+  ...
+}
+
+module "cloud_monitoring" {
+  source            = "terraform-ibm-modules/cloud-monitoring/ibm"
+  version           = "1.2.2"
+  ...
+  ...
+}
+
+module "metrics_router" {
+  source    = "terraform-ibm-modules/cloud-monitoring/ibm//modules/metrics_routing"
+  version   = "1.2.2"
+  ...
+  ...
+}
+
+module "activity_tracker" {
+  source            = "terraform-ibm-modules/activity-tracker/ibm"
+  version           = "1.0.0"
+  ...
+  ...
+}
+```
+
+In order to prevent infrastructure from being recreated when migrating, you can use terraform [moved block references](https://developer.hashicorp.com/terraform/language/moved). Below are a full list of required moved blocks:
+
+```hcl
+# Cloud Logs
+moved {
+  from = module.observability_instance.module.cloud_logs[0]
+  to   = module.cloud_logs[0]
+}
+
+# Cloud Monitoring
+moved {
+  from = module.observability_instance.module.cloud_monitoring[0].ibm_resource_instance.cloud_monitoring[0]
+  to   = module.cloud_monitoring[0].ibm_resource_instance.cloud_monitoring
+}
+
+moved {
+  from = module.observability_instance.module.cloud_monitoring[0].ibm_resource_key.resource_key[0]
+  to   = module.cloud_monitoring[0].ibm_resource_key.resource_key
+}
+
+moved {
+  from = module.observability_instance.module.cloud_monitoring[0].ibm_resource_tag.cloud_monitoring_tag
+  to   = module.cloud_monitoring[0].ibm_resource_tag.cloud_monitoring_tag
+}
+
+# Metrics Routing
+moved {
+  from = module.observability_instance.module.metric_routing
+  to   = module.metrics_router
+}
+
+# Activity Tracker
+moved {
+  from = module.observability_instance.module.activity_tracker
+  to   = module.activity_tracker
+}
+```
+
+After upgrading your code and running a terraform plan, you may see the following expected change:
+- Destroy and re-create of the Activity Tracker / COS service to service authorization policy.
+  - In the new Activity Tracker module, the authorization policy has been updated so that it is now scoped the exact Object storage bucket, where previously it was scoped to the full Object Storage instance.
+  - The new logic has been implemented in such a way that the new authorization policy will be created before the old one is deleted, meaning there will be no disruption to every day services.
+  - The plan output will look something like this:
+    ```
+    # module.activity_tracker.ibm_iam_authorization_policy.atracker_cos["con-cos-target"] must be replaced
+    # (moved from module.observability_instance.module.activity_tracker.ibm_iam_authorization_policy.atracker_cos["con-cos-target"])
+    +/- resource "ibm_iam_authorization_policy" "atracker_cos" {
+        ~ id                          = "1da3880a-b623-46fa-a8f3-362dc51c4774" -> (known after apply)
+        + source_resource_group_id    = (known after apply)
+        + source_resource_instance_id = (known after apply)
+        + source_resource_type        = (known after apply)
+        ~ source_service_account      = "abac0df06b644a9cabc6e44f55b3880e" -> (known after apply)
+        + target_resource_group_id    = (known after apply)
+        ~ target_resource_instance_id = "7fa80cb2-2771-460a-bcdd-b52dfbf959e5" -> (known after apply)
+        + target_resource_type        = (known after apply)
+        ~ target_service_name         = "cloud-object-storage" -> (known after apply)
+        ~ transaction_id              = "184970857dde438f9e05d298a55711ea" -> (known after apply)
+        + version                     = (known after apply)
+            # (3 unchanged attributes hidden)
+
+        + resource_attributes { # forces replacement
+            + name     = "resource"
+            + operator = "stringEquals"
+            + value    = "con-at-events-cos-bucket-jm90"
+            }
+        + resource_attributes { # forces replacement
+            + name     = "resourceType"
+            + operator = "stringEquals"
+            + value    = "bucket"
+            }
+
+        ~ subject_attributes (known after apply)
+
+            # (3 unchanged blocks hidden)
+        }
+    ```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -27,22 +27,22 @@ module "cloud_logs" {
 }
 
 module "cloud_monitoring" {
-  source            = "terraform-ibm-modules/cloud-monitoring/ibm"
-  version           = "1.2.2"
+  source  = "terraform-ibm-modules/cloud-monitoring/ibm"
+  version = "1.2.2"
   ...
   ...
 }
 
 module "metrics_router" {
-  source    = "terraform-ibm-modules/cloud-monitoring/ibm//modules/metrics_routing"
-  version   = "1.2.2"
+  source   = "terraform-ibm-modules/cloud-monitoring/ibm//modules/metrics_routing"
+  version  = "1.2.2"
   ...
   ...
 }
 
 module "activity_tracker" {
-  source            = "terraform-ibm-modules/activity-tracker/ibm"
-  version           = "1.0.0"
+  source  = "terraform-ibm-modules/activity-tracker/ibm"
+  version = "1.0.0"
   ...
   ...
 }


### PR DESCRIPTION
### Description

Add deprecation and migration docs. Propose to create a patch release so the hashicorp terraform registry doc shows the deprecation message. 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
